### PR TITLE
Add dropdown menu for Organisers with relevant pages

### DIFF
--- a/community-code-of-conducts.html
+++ b/community-code-of-conducts.html
@@ -1,0 +1,454 @@
+<!DOCTYPE HTML>
+<html lang="en">
+
+<head>
+
+  <!-- Display -->
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+  <!-- Identity -->
+  <title>Community: Code of Conducts</title>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta property="og:title" content="Community: Code of Conducts" />
+  <meta property="og:type" content="website" />
+  <meta name="description" content="Community: Code of Conducts page for the PSF Diversity and Inclusion Workgroup.">
+  <meta property="og:url" content="https://url" />
+  <meta property="og:image" content="" />
+  <link rel="shortcut icon" href="assets/images/favicon.ico" type="image/x-icon" />
+
+  <!-- Vendor Style Sheet -->
+  <link rel="stylesheet" href="assets/css/vendor/font-family.min.css" />
+  <link rel="stylesheet" href="assets/css/vendor/font-awesome.min.css" />
+  <link rel="stylesheet" href="assets/css/vendor/menu-engine.min.css" />
+  <link rel="stylesheet" href="assets/css/vendor/menu-grid.min.css" />
+  <link rel="stylesheet" href="assets/css/vendor/bootstrap.min.css" />
+  <link rel="stylesheet" href="assets/css/vendor/swiper.min.css" />
+  <link rel="stylesheet" href="assets/css/vendor/dynamic-slider.min.css" />
+  <link rel="stylesheet" href="assets/css/vendor/bricklayer.min.css" />
+  <link rel="stylesheet" href="assets/css/vendor/lightbox.min.css" />
+  <link rel="stylesheet" href="assets/css/vendor/aos.min.css" />
+
+  <!-- Main Style Sheet -->
+  <link rel="stylesheet" href="assets/css/theme.css" />
+  <link rel="stylesheet" href="assets/css/core.css" />
+  <link rel="stylesheet" href="assets/css/main.css" />
+
+</head>
+
+<body class="shock-body">
+
+  <!-- Header -->
+  <header id="header" class="shock-header">
+    <!-- Navbar -->
+    <nav id="navbar" class="navbar navbar-centered navbar-expand-lg auto-hide scheme-1 tertiary">
+      <div class="container">
+        <!-- Brand -->
+        <a class="navbar-brand" href="https://psf.github.io/diversity-and-inclusion-wg/" target="_blank">
+          <img src="assets/images/logo-dni.svg" data-logo-alt="assets/images/logo-dni.svg"
+            data-logo-mobile="assets/images/logo-dni.svg" alt="PSF Diversity and Inclusion WG" class="logo" />
+        </a>
+        <!-- Responsive menu toggle -->
+        <button class="navbar-toggler" data-bs-target="#navbar-items" data-bs-toggle="collapse" aria-expanded="false">
+          <span class="navbar-toggler-icon">
+            <span class="line"></span>
+            <span class="line"></span>
+            <span class="line"></span>
+          </span>
+        </button>
+        <div id="navbar-items" class="collapse navbar-collapse">
+          <div class="navbar-left">
+            <!-- Link -->
+            <ul class="navbar-nav">
+              <li class="nav-item">
+                <a href="#about" class="nav-link flutter-underline">
+                  <span class="text">Who are we</span>
+                  <svg class="flutter-underline-graphic" width="300%" height="100%" viewBox="0 0 1200 60"
+                    preserveAspectRatio="none">
+                    <path
+                      d="M0,56.5c0,0,298.666,0,399.333,0C448.336,56.5,513.994,46,597,46c77.327,0,135,10.5,200.999,10.5c95.996,0,402.001,0,402.001,0">
+                    </path>
+                  </svg>
+                </a>
+              </li>
+              <a href="#agenda" class="nav-link flutter-underline">
+                <span class="text">Agenda</span>
+                <svg class="flutter-underline-graphic" width="300%" height="100%" viewBox="0 0 1200 60"
+                  preserveAspectRatio="none">
+                  <path
+                    d="M0,56.5c0,0,298.666,0,399.333,0C448.336,56.5,513.994,46,597,46c77.327,0,135,10.5,200.999,10.5c95.996,0,402.001,0,402.001,0">
+                  </path>
+                </svg>
+              </a>
+              <li class="nav-item dropdown has-megamenu hover">
+                <a class="nav-link dropdown-toggle has-icon flutter-underline" href="#" data-bs-toggle="dropdown">
+                  <span class="text">Videos</span><img class="image-icon dropdown-icon"
+                    src="assets/svg/chevron-down-outline.svg" alt="Icon name" data-dni-icon="32" />
+                  <svg class="flutter-underline-graphic" width="300%" height="100%" viewBox="0 0 1200 60"
+                    preserveAspectRatio="none">
+                    <path
+                      d="M0,56.5c0,0,298.666,0,399.333,0C448.336,56.5,513.994,46,597,46c77.327,0,135,10.5,200.999,10.5c95.996,0,402.001,0,402.001,0">
+                    </path>
+                  </svg>
+                </a>
+                <div class="dropdown-menu megamenu animate fade-down" role="menu">
+                  <div class="container">
+                    <div class="section-inner-expanded">
+                      <div class="row g-3">
+                        <div class="col-12 col-md-6">
+                          <div class="megamenu-item h-auto">
+                            <h6 class="title text-white">Previous Meets</h6>
+                          </div>
+                          <div class="row g-3">
+                            <div class="col-12 col-md-6">
+                              <div class="megamenu-item">
+                                <ul class="nav-list list-unstyled">
+                                  <li class="nav-item">
+                                    <a href="-" class="nav-link">
+                                      <span class="text">January 31, 2023</span>
+                                      <span class="badge ms-05 primary-15 primary-15-hover">
+                                        <span class="badge-text primary primary-hover">Latest</span>
+                                      </span>
+                                    </a>
+                                  </li>
+                                </ul>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="col-12 col-md-6 col-lg-3">
+                          <div class="megamenu-item">
+                            <a href="element-carousel.html" target="_blank" class="megamenu-image secondary">
+                              <img src="assets/images/gif/d&i.gif" alt="Image name" class="image">
+                              <span class="title"></span>
+                            </a>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </li>
+            </ul>
+          </div>
+          <div class="navbar-right">
+            <!-- Link -->
+            <ul class="navbar-nav">
+              <li class="nav-item dropdown has-megamenu hover">
+                <a href="#faqs" class="nav-link flutter-underline">
+                  <span class="text">FAQ</span>
+                  <svg class="flutter-underline-graphic" width="300%" height="100%" viewBox="0 0 1200 60"
+                    preserveAspectRatio="none">
+                    <path
+                      d="M0,56.5c0,0,298.666,0,399.333,0C448.336,56.5,513.994,46,597,46c77.327,0,135,10.5,200.999,10.5c95.996,0,402.001,0,402.001,0">
+                    </path>
+                  </svg>
+                </a>
+                <div class="dropdown-menu megamenu animate fade-down" role="menu">
+                  <div class="container">
+                  </div>
+                </div>
+              </li>
+              <li class="nav-item dropdown has-megamenu hover">
+                <a class="nav-link dropdown-toggle has-icon flutter-underline" href="#" data-bs-toggle="dropdown">
+                  <span class="text">Community Spotlight</span><img class="image-icon dropdown-icon"
+                    src="assets/svg/chevron-down-outline.svg" alt="Icon name" data-dni-icon="32" />
+                  <svg class="flutter-underline-graphic" width="300%" height="100%" viewBox="0 0 1200 60"
+                    preserveAspectRatio="none">
+                    <path
+                      d="M0,56.5c0,0,298.666,0,399.333,0C448.336,56.5,513.994,46,597,46c77.327,0,135,10.5,200.999,10.5c95.996,0,402.001,0,402.001,0">
+                    </path>
+                  </svg>
+                </a>
+                <div class="dropdown-menu megamenu animate fade-down" role="menu">
+                  <div class="container">
+                    <div class="section-inner-expanded">
+                      <div class="row g-3">
+                        <div class="col-12 col-md-6">
+                          <div class="megamenu-item h-auto">
+                            <h6 class="title text-white">Most Recent Showcase</h6>
+                          </div>
+                          <div class="row g-3">
+                            <div class="col-12 col-md-6">
+                              <div class="megamenu-item">
+                                <ul class="nav-list list-unstyled">
+                                  <li class="nav-item">
+                                    <a href="https://observablehq.com/@terezaif/who-voted-in-the-psf-board-elections"
+                                      class="nav-link">
+                                      <span class="text">PSF ELection Voters</span>
+                                      <span class="badge ms-05 primary-15 primary-15-hover">
+                                        <span class="badge-text primary primary-hover">Latest</span>
+                                      </span>
+                                    </a>
+                                  </li>
+                                  <li class="nav-item">
+                                    <a href="post-2.html" class="nav-link parent">
+                                      <span class="text">Story 2</span>
+                                    </a>
+                                  </li>
+                                  <li class="nav-item">
+                                    <a href="post-3.html" class="nav-link">
+                                      <span class="text">Story 3</span>
+                                    </a>
+                                  </li>
+                                  <li class="nav-item">
+                                    <a href="post-4.html" class="nav-link parent">
+                                      <span class="text">Story 4</span>
+                                    </a>
+                                  </li>
+                                  <li class="nav-item">
+                                    <a href="post-5.html" class="nav-link">
+                                      <span class="text">Story 5</span>
+                                    </a>
+                                  </li>
+                                </ul>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="col-12 col-md-6 col-lg-3">
+                          <div class="megamenu-item">
+                            <h6 class="title text-white">Python Heroes</h6>
+                            <ul class="nav-list list-unstyled">
+                              <li class="nav-item">
+                                <a href="blog-post-1.html" class="nav-link">
+                                  <span class="text">Hero 1</span>
+                                </a>
+                              </li>
+                              <li class="nav-item">
+                                <a href="blog-post-2.html" class="nav-link">
+                                  <span class="text">Hero 2</span>
+                                </a>
+                              </li>
+                              <li class="nav-item">
+                                <a href="blog-post-3.html" class="nav-link">
+                                  <span class="text">Hero 3</span>
+                                </a>
+                              </li>
+                              <li class="nav-item">
+                                <a href="blog-post-4.html" class="nav-link">
+                                  <span class="text">Hero 4</span>
+                                </a>
+                              </li>
+                              <li class="nav-item">
+                                <a href="blog-post-5.html" class="nav-link">
+                                  <span class="text">Hero 5</span>
+                                </a>
+                              </li>
+                              <li class="nav-item">
+                                <a href="blog-post-6.html" class="nav-link">
+                                  <span class="text">Hero 6</span>
+                                </a>
+                              </li>
+                            </ul>
+                          </div>
+                        </div>
+                        <div class="col-12 col-md-6 col-lg-3">
+                          <div class="megamenu-item">
+                            <a href="element-carousel.html" target="_blank" class="megamenu-image secondary">
+                              <img src="assets/images/gif/spot.gif" alt="spotlight gif" class="image">
+                              <span class="title">Spotlight</span>
+                            </a>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </li>
+              <li class="nav-item dropdown has-megamenu hover">
+                <a class="nav-link dropdown-toggle has-icon flutter-underline" href="#" data-bs-toggle="dropdown">
+                  <span class="text">Organisers</span><img class="image-icon dropdown-icon"
+                    src="assets/svg/chevron-down-outline.svg" alt="Icon name" data-dni-icon="32" />
+                  <svg class="flutter-underline-graphic" width="300%" height="100%" viewBox="0 0 1200 60"
+                    preserveAspectRatio="none">
+                    <path
+                      d="M0,56.5c0,0,298.666,0,399.333,0C448.336,56.5,513.994,46,597,46c77.327,0,135,10.5,200.999,10.5c95.996,0,402.001,0,402.001,0">
+                    </path>
+                  </svg>
+                </a>
+                <div class="dropdown-menu megamenu animate fade-down" role="menu">
+                  <div class="container">
+                    <div class="section-inner-expanded">
+                      <div class="row g-3">
+                        <div class="col-12 col-md-6">
+                          <div class="megamenu-item h-auto">
+                            <h6 class="title text-white">Organisers</h6>
+                          </div>
+                          <div class="row g-3">
+                            <div class="col-12 col-md-6">
+                              <div class="megamenu-item">
+                                <ul class="nav-list list-unstyled">
+                                  <li class="nav-item">
+                                    <a href="education.html" class="nav-link">
+                                      <span class="text">Education</span>
+                                    </a>
+                                  </li>
+                                  <li class="nav-item">
+                                    <a href="community-code-of-conducts.html" class="nav-link">
+                                      <span class="text">Community: Code of Conducts</span>
+                                    </a>
+                                  </li>
+                                  <li class="nav-item">
+                                    <a href="di-practices.html" class="nav-link">
+                                      <span class="text">D&I Practices</span>
+                                    </a>
+                                  </li>
+                                  <li class="nav-item">
+                                    <a href="event-organiser-material.html" class="nav-link">
+                                      <span class="text">Event Organiser Material</span>
+                                    </a>
+                                  </li>
+                                </ul>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="col-12 col-md-6 col-lg-3">
+                          <div class="megamenu-item">
+                            <a href="element-carousel.html" target="_blank" class="megamenu-image secondary">
+                              <img src="assets/images/gif/d&i.gif" alt="Image name" class="image">
+                              <span class="title"></span>
+                            </a>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </nav>
+  </header>
+
+  <!-- Main -->
+  <main id="main" class="shock-main bg-color black">
+
+    <!-- Banner -->
+    <section class="shock-section bg-image bg-fixed position-x-left" data-bg-image="assets/images/jpg/bg3.jpg">
+      <div class="container">
+        <div class="holder vh-100 align-h-right align-v-center">
+          <!-- Intro -->
+          <div class="side-intro max-w-50">
+            <h2 class="title">
+              <span class="text-1 text-style-1 text-outline text-gradient scheme-2"
+                data-text-color="#101e20">Community</span>
+              <span class="text-2 text-style-2 text-italic text-gradient scheme-2">Code of Conducts</span>
+            </h2>
+            <div class="description text-style-12 gray">
+              <p>Ensuring a safe and inclusive environment for all community members.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Content -->
+    <section class="shock-section pt-5 pb-3">
+      <div class="container">
+        <!-- Intro -->
+        <div class="extended-intro max-w-85">
+          <div class="wrapper">
+            <div class="left-column">
+              <h2 class="title">
+                <span class="text-1 text-style-2 text-outline text-gradient scheme-2" data-text-color="#1e1e24">Our Commitment</span>
+                <span class="text-2 text-style-3 text-italic text-gradient scheme-2">Creating a welcoming community</span>
+              </h2>
+              <div class="description text-style-12 gray">
+                <p>We are committed to providing a friendly, safe, and welcoming environment for all, regardless of gender, sexual orientation, disability, ethnicity, religion, or any other characteristic.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <!-- Code of Conducts -->
+        <div class="content max-w-85">
+          <h3 class="title text-style-11 white">Code of Conducts</h3>
+          <div class="description text-style-12 gray">
+            <p>Our community is dedicated to providing a harassment-free experience for everyone. We do not tolerate harassment of participants in any form. All communication should be appropriate for a professional audience including people of many different backgrounds.</p>
+            <p>Please be kind and courteous. There’s no need to be mean or rude. Respect that people have differences of opinion and that every design or implementation choice carries a trade-off and numerous costs. There is seldom a single right answer.</p>
+            <p>We are here to help each other learn and grow. Be patient and generous in your interactions with others.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <!-- Footer -->
+  <footer id="footer" class="dni-footer scheme-1 tertiary">
+    <div class="footer-content focus-trigger">
+      <div class="container">
+        <div class="row g-3">
+          <div class="col-12 col-md-6 col-lg-3">
+            <div class="footer-item">
+              <!-- Brand -->
+              <a href="/" class="footer-brand">
+                <img src="assets/images/logo-dni.svg" alt="PSF Diversity & Inclusion Workgroup" class="logo" />
+                <span class="logo-after-text">D&I Workgroup</span>
+              </a>
+              <img src="assets/images/png/psf-logo-white.png" class="image" alt="New York Statue of Liberty" />
+              <!-- Text -->
+              <div class="footer-text">
+                <p>The Diversity and Inclusion Working Group is a volunteer workgroup of the Python Software Foundation.
+                </p>
+              </div>
+            </div>
+            <div class="footer-item">
+              <!-- Icon list -->
+              <div class="list-wrapper">
+                <ul class="icon-h-list">
+                  <li class="item">
+                    <a href="https://twitter.com/ThePSF" class="link gray tertiary-hover hover-rotate"><i
+                        class="icon fab fa-twitter"></i></a>
+                  </li>
+                  <li class="item">
+                    <a href="https://www.linkedin.com/company/thepsf/" class="link gray tertiary-hover hover-rotate"><i
+                        class="icon fab fa-linkedin-in"></i></a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="bottom-bar">
+      <div class="text">© 2022 - All rights reserved. This website is maintained by the <a
+          href="https://www.python.org/psf-landing/" class="link gray primary-hover"><u>PSF</u></a> <a
+          href="https://wiki.python.org/psf/DiversityandInclusionWG" class="link gray primary-hover"><u>Diversity and
+            Inclusion</u></a> Workgroup.</div>
+    </div>
+  </footer>
+
+  <!-- Vendor JavaScript -->
+  <script src="assets/js/vendor/jquery.min.js"></script>
+  <script src="assets/js/vendor/imagesloaded.pkgd.min.js"></script>
+  <script src="assets/js/vendor/inview.min.js"></script>
+  <script src="assets/js/vendor/menu-engine.min.js"></script>
+  <script src="assets/js/vendor/menu-grid.min.js"></script>
+  <script src="assets/js/vendor/bootstrap.min.js"></script>
+  <script src="assets/js/vendor/swiper.min.js"></script>
+  <script src="assets/js/vendor/anime.min.js"></script>
+  <script src="assets/js/vendor/dynamic-slider.min.js"></script>
+  <script src="assets/js/vendor/shuffle.min.js"></script>
+  <script src="assets/js/vendor/stickybits.min.js"></script>
+  <script src="assets/js/vendor/bricklayer.min.js"></script>
+  <script src="assets/js/vendor/lightbox.min.js"></script>
+  <script src="assets/js/vendor/typed.min.js"></script>
+  <script src="assets/js/vendor/progressbar.min.js"></script>
+  <script src="assets/js/vendor/map-styles.min.js"></script>
+  <script src="assets/js/vendor/magnetic-effect.min.js"></script>
+  <script src='assets/js/vendor/gsap.min.js'></script>
+  <script src="assets/js/vendor/aos.min.js"></script>
+  <script src="assets/js/vendor/lax.min.js"></script>
+  <script src="assets/js/vendor/cursor-effect.min.js"></script>
+
+  <!-- Main JavaScript -->
+  <script src="assets/js/main.js"></script>
+
+</body>
+
+</html>

--- a/di-practices.html
+++ b/di-practices.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>D&I Practices</title>
+  <link rel="stylesheet" href="assets/css/theme.css">
+  <link rel="stylesheet" href="assets/css/core.css">
+  <link rel="stylesheet" href="assets/css/main.css">
+</head>
+
+<body>
+  <header>
+    <nav>
+      <ul>
+        <li><a href="index.html">Home</a></li>
+        <li><a href="education.html">Education</a></li>
+        <li><a href="community-code-of-conducts.html">Community: Code of Conducts</a></li>
+        <li><a href="di-practices.html">D&I Practices</a></li>
+        <li><a href="event-organiser-material.html">Event Organiser Material</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main>
+    <section>
+      <h1>D&I Practices</h1>
+      <p>Welcome to the D&I Practices page. Here you will find information and resources related to diversity and inclusion practices within the Python community.</p>
+      <h2>Best Practices</h2>
+      <p>We encourage the adoption of the following best practices to promote diversity and inclusion:</p>
+      <ul>
+        <li>Foster an inclusive environment where everyone feels welcome and valued.</li>
+        <li>Promote diverse representation in leadership and decision-making roles.</li>
+        <li>Provide equal opportunities for participation and growth.</li>
+        <li>Address and prevent discrimination, harassment, and bias.</li>
+        <li>Encourage open and respectful communication.</li>
+      </ul>
+      <h2>Resources</h2>
+      <p>Here are some resources to help you implement and improve D&I practices:</p>
+      <ul>
+        <li><a href="https://example.com/resource1">Resource 1</a></li>
+        <li><a href="https://example.com/resource2">Resource 2</a></li>
+        <li><a href="https://example.com/resource3">Resource 3</a></li>
+      </ul>
+    </section>
+  </main>
+
+  <footer>
+    <p>&copy; 2023 Python Software Foundation. All rights reserved.</p>
+  </footer>
+</body>
+
+</html>

--- a/di-practices.html
+++ b/di-practices.html
@@ -8,6 +8,16 @@
   <link rel="stylesheet" href="assets/css/theme.css">
   <link rel="stylesheet" href="assets/css/core.css">
   <link rel="stylesheet" href="assets/css/main.css">
+  <link rel="stylesheet" href="assets/css/vendor/font-family.min.css">
+  <link rel="stylesheet" href="assets/css/vendor/font-awesome.min.css">
+  <link rel="stylesheet" href="assets/css/vendor/menu-engine.min.css">
+  <link rel="stylesheet" href="assets/css/vendor/menu-grid.min.css">
+  <link rel="stylesheet" href="assets/css/vendor/bootstrap.min.css">
+  <link rel="stylesheet" href="assets/css/vendor/swiper.min.css">
+  <link rel="stylesheet" href="assets/css/vendor/dynamic-slider.min.css">
+  <link rel="stylesheet" href="assets/css/vendor/bricklayer.min.css">
+  <link rel="stylesheet" href="assets/css/vendor/lightbox.min.css">
+  <link rel="stylesheet" href="assets/css/vendor/aos.min.css">
 </head>
 
 <body>
@@ -49,6 +59,29 @@
   <footer>
     <p>&copy; 2023 Python Software Foundation. All rights reserved.</p>
   </footer>
+
+  <script src="assets/js/vendor/jquery.min.js"></script>
+  <script src="assets/js/vendor/imagesloaded.pkgd.min.js"></script>
+  <script src="assets/js/vendor/inview.min.js"></script>
+  <script src="assets/js/vendor/menu-engine.min.js"></script>
+  <script src="assets/js/vendor/menu-grid.min.js"></script>
+  <script src="assets/js/vendor/bootstrap.min.js"></script>
+  <script src="assets/js/vendor/swiper.min.js"></script>
+  <script src="assets/js/vendor/anime.min.js"></script>
+  <script src="assets/js/vendor/dynamic-slider.min.js"></script>
+  <script src="assets/js/vendor/shuffle.min.js"></script>
+  <script src="assets/js/vendor/stickybits.min.js"></script>
+  <script src="assets/js/vendor/bricklayer.min.js"></script>
+  <script src="assets/js/vendor/lightbox.min.js"></script>
+  <script src="assets/js/vendor/typed.min.js"></script>
+  <script src="assets/js/vendor/progressbar.min.js"></script>
+  <script src="assets/js/vendor/map-styles.min.js"></script>
+  <script src="assets/js/vendor/magnetic-effect.min.js"></script>
+  <script src='assets/js/vendor/gsap.min.js'></script>
+  <script src="assets/js/vendor/aos.min.js"></script>
+  <script src="assets/js/vendor/lax.min.js"></script>
+  <script src="assets/js/vendor/cursor-effect.min.js"></script>
+  <script src="assets/js/main.js"></script>
 </body>
 
 </html>

--- a/education.html
+++ b/education.html
@@ -1,0 +1,515 @@
+<!DOCTYPE HTML>
+<html lang="en">
+
+<head>
+
+  <!-- Display -->
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+  <!-- Identity -->
+  <title>Education - PSF Diversity and Inclusion Workgroup</title>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta property="og:title" content="Education - PSF D&I Workgroup" />
+  <meta property="og:type" content="website" />
+  <meta name="description" content="Education resources and initiatives by the PSF Diversity and Inclusion Workgroup.">
+  <meta property="og:url" content="https://url" />
+  <meta property="og:image" content="" />
+  <link rel="shortcut icon" href="assets/images/favicon.ico" type="image/x-icon" />
+
+  <!-- Vendor Style Sheet -->
+  <link rel="stylesheet" href="assets/css/vendor/font-family.min.css" />
+  <link rel="stylesheet" href="assets/css/vendor/font-awesome.min.css" />
+  <link rel="stylesheet" href="assets/css/vendor/menu-engine.min.css" />
+  <link rel="stylesheet" href="assets/css/vendor/menu-grid.min.css" />
+  <link rel="stylesheet" href="assets/css/vendor/bootstrap.min.css" />
+  <link rel="stylesheet" href="assets/css/vendor/swiper.min.css" />
+  <link rel="stylesheet" href="assets/css/vendor/dynamic-slider.min.css" />
+  <link rel="stylesheet" href="assets/css/vendor/bricklayer.min.css" />
+  <link rel="stylesheet" href="assets/css/vendor/lightbox.min.css" />
+  <link rel="stylesheet" href="assets/css/vendor/aos.min.css" />
+
+  <!-- Main Style Sheet -->
+  <link rel="stylesheet" href="assets/css/theme.css" />
+  <link rel="stylesheet" href="assets/css/core.css" />
+  <link rel="stylesheet" href="assets/css/main.css" />
+
+</head>
+
+<body class="shock-body">
+
+  <!-- Header -->
+  <header id="header" class="shock-header">
+    <!-- Navbar -->
+    <nav id="navbar" class="navbar navbar-centered navbar-expand-lg auto-hide scheme-1 tertiary">
+      <div class="container">
+        <!-- Brand -->
+        <a class="navbar-brand" href="https://psf.github.io/diversity-and-inclusion-wg/" target="_blank">
+          <img src="assets/images/logo-dni.svg" data-logo-alt="assets/images/logo-dni.svg"
+            data-logo-mobile="assets/images/logo-dni.svg" alt="PSF Diversity and Inclusion WG" class="logo" />
+        </a>
+        <!-- Responsive menu toggle -->
+        <button class="navbar-toggler" data-bs-target="#navbar-items" data-bs-toggle="collapse" aria-expanded="false">
+          <span class="navbar-toggler-icon">
+            <span class="line"></span>
+            <span class="line"></span>
+            <span class="line"></span>
+          </span>
+        </button>
+        <div id="navbar-items" class="collapse navbar-collapse">
+          <div class="navbar-left">
+            <!-- Link -->
+            <ul class="navbar-nav">
+              <li class="nav-item">
+                <a href="#about" class="nav-link flutter-underline">
+                  <span class="text">Who are we</span>
+                  <svg class="flutter-underline-graphic" width="300%" height="100%" viewBox="0 0 1200 60"
+                    preserveAspectRatio="none">
+                    <path
+                      d="M0,56.5c0,0,298.666,0,399.333,0C448.336,56.5,513.994,46,597,46c77.327,0,135,10.5,200.999,10.5c95.996,0,402.001,0,402.001,0">
+                    </path>
+                  </svg>
+                </a>
+              </li>
+              <a href="#agenda" class="nav-link flutter-underline">
+                <span class="text">Agenda</span>
+                <svg class="flutter-underline-graphic" width="300%" height="100%" viewBox="0 0 1200 60"
+                  preserveAspectRatio="none">
+                  <path
+                    d="M0,56.5c0,0,298.666,0,399.333,0C448.336,56.5,513.994,46,597,46c77.327,0,135,10.5,200.999,10.5c95.996,0,402.001,0,402.001,0">
+                  </path>
+                </svg>
+              </a>
+              <li class="nav-item dropdown has-megamenu hover">
+                <a class="nav-link dropdown-toggle has-icon flutter-underline" href="#" data-bs-toggle="dropdown">
+                  <span class="text">Videos</span><img class="image-icon dropdown-icon"
+                    src="assets/svg/chevron-down-outline.svg" alt="Icon name" data-dni-icon="32" />
+                  <svg class="flutter-underline-graphic" width="300%" height="100%" viewBox="0 0 1200 60"
+                    preserveAspectRatio="none">
+                    <path
+                      d="M0,56.5c0,0,298.666,0,399.333,0C448.336,56.5,513.994,46,597,46c77.327,0,135,10.5,200.999,10.5c95.996,0,402.001,0,402.001,0">
+                    </path>
+                  </svg>
+                </a>
+                <div class="dropdown-menu megamenu animate fade-down" role="menu">
+                  <div class="container">
+                    <div class="section-inner-expanded">
+                      <div class="row g-3">
+                        <div class="col-12 col-md-6">
+                          <div class="megamenu-item h-auto">
+                            <h6 class="title text-white">Previous Meets</h6>
+                          </div>
+                          <div class="row g-3">
+                            <div class="col-12 col-md-6">
+                              <div class="megamenu-item">
+                                <ul class="nav-list list-unstyled">
+                                  <li class="nav-item">
+                                    <a href="-" class="nav-link">
+                                      <span class="text">January 31, 2023</span>
+                                      <span class="badge ms-05 primary-15 primary-15-hover">
+                                        <span class="badge-text primary primary-hover">Latest</span>
+                                      </span>
+                                    </a>
+                                  </li>
+                                </ul>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="col-12 col-md-6 col-lg-3">
+                          <div class="megamenu-item">
+                            <a href="element-carousel.html" target="_blank" class="megamenu-image secondary">
+                              <img src="assets/images/gif/d&i.gif" alt="Image name" class="image">
+                              <span class="title"></span>
+                            </a>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </li>
+            </ul>
+          </div>
+          <div class="navbar-right">
+            <!-- Link -->
+            <ul class="navbar-nav">
+              <li class="nav-item dropdown has-megamenu hover">
+                <a href="#faqs" class="nav-link flutter-underline">
+                  <span class="text">FAQ</span>
+                  <svg class="flutter-underline-graphic" width="300%" height="100%" viewBox="0 0 1200 60"
+                    preserveAspectRatio="none">
+                    <path
+                      d="M0,56.5c0,0,298.666,0,399.333,0C448.336,56.5,513.994,46,597,46c77.327,0,135,10.5,200.999,10.5c95.996,0,402.001,0,402.001,0">
+                    </path>
+                  </svg>
+                </a>
+                <div class="dropdown-menu megamenu animate fade-down" role="menu">
+                  <div class="container">
+                  </div>
+                </div>
+              </li>
+              <li class="nav-item dropdown has-megamenu hover">
+                <a class="nav-link dropdown-toggle has-icon flutter-underline" href="#" data-bs-toggle="dropdown">
+                  <span class="text">Community Spotlight</span><img class="image-icon dropdown-icon"
+                    src="assets/svg/chevron-down-outline.svg" alt="Icon name" data-dni-icon="32" />
+                  <svg class="flutter-underline-graphic" width="300%" height="100%" viewBox="0 0 1200 60"
+                    preserveAspectRatio="none">
+                    <path
+                      d="M0,56.5c0,0,298.666,0,399.333,0C448.336,56.5,513.994,46,597,46c77.327,0,135,10.5,200.999,10.5c95.996,0,402.001,0,402.001,0">
+                    </path>
+                  </svg>
+                </a>
+                <div class="dropdown-menu megamenu animate fade-down" role="menu">
+                  <div class="container">
+                    <div class="section-inner-expanded">
+                      <div class="row g-3">
+                        <div class="col-12 col-md-6">
+                          <div class="megamenu-item h-auto">
+                            <h6 class="title text-white">Most Recent Showcase</h6>
+                          </div>
+                          <div class="row g-3">
+                            <div class="col-12 col-md-6">
+                              <div class="megamenu-item">
+                                <ul class="nav-list list-unstyled">
+                                  <li class="nav-item">
+                                    <a href="https://observablehq.com/@terezaif/who-voted-in-the-psf-board-elections"
+                                      class="nav-link">
+                                      <span class="text">PSF ELection Voters</span>
+                                      <span class="badge ms-05 primary-15 primary-15-hover">
+                                        <span class="badge-text primary primary-hover">Latest</span>
+                                      </span>
+                                    </a>
+                                  </li>
+                                  <li class="nav-item">
+                                    <a href="post-2.html" class="nav-link parent">
+                                      <span class="text">Story 2</span>
+                                    </a>
+                                  </li>
+                                  <li class="nav-item">
+                                    <a href="post-3.html" class="nav-link">
+                                      <span class="text">Story 3</span>
+                                    </a>
+                                  </li>
+                                  <li class="nav-item">
+                                    <a href="post-4.html" class="nav-link parent">
+                                      <span class="text">Story 4</span>
+                                    </a>
+                                  </li>
+                                  <li class="nav-item">
+                                    <a href="post-5.html" class="nav-link">
+                                      <span class="text">Story 5</span>
+                                    </a>
+                                  </li>
+                                </ul>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="col-12 col-md-6 col-lg-3">
+                          <div class="megamenu-item">
+                            <h6 class="title text-white">Python Heroes</h6>
+                            <ul class="nav-list list-unstyled">
+                              <li class="nav-item">
+                                <a href="blog-post-1.html" class="nav-link">
+                                  <span class="text">Hero 1</span>
+                                </a>
+                              </li>
+                              <li class="nav-item">
+                                <a href="blog-post-2.html" class="nav-link">
+                                  <span class="text">Hero 2</span>
+                                </a>
+                              </li>
+                              <li class="nav-item">
+                                <a href="blog-post-3.html" class="nav-link">
+                                  <span class="text">Hero 3</span>
+                                </a>
+                              </li>
+                              <li class="nav-item">
+                                <a href="blog-post-4.html" class="nav-link">
+                                  <span class="text">Hero 4</span>
+                                </a>
+                              </li>
+                              <li class="nav-item">
+                                <a href="blog-post-5.html" class="nav-link">
+                                  <span class="text">Hero 5</span>
+                                </a>
+                              </li>
+                              <li class="nav-item">
+                                <a href="blog-post-6.html" class="nav-link">
+                                  <span class="text">Hero 6</span>
+                                </a>
+                              </li>
+                            </ul>
+                          </div>
+                        </div>
+                        <div class="col-12 col-md-6 col-lg-3">
+                          <div class="megamenu-item">
+                            <a href="element-carousel.html" target="_blank" class="megamenu-image secondary">
+                              <img src="assets/images/gif/spot.gif" alt="spotlight gif" class="image">
+                              <span class="title">Spotlight</span>
+                            </a>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </li>
+              <li class="nav-item dropdown has-megamenu hover">
+                <a class="nav-link dropdown-toggle has-icon flutter-underline" href="#" data-bs-toggle="dropdown">
+                  <span class="text">Organisers</span><img class="image-icon dropdown-icon"
+                    src="assets/svg/chevron-down-outline.svg" alt="Icon name" data-dni-icon="32" />
+                  <svg class="flutter-underline-graphic" width="300%" height="100%" viewBox="0 0 1200 60"
+                    preserveAspectRatio="none">
+                    <path
+                      d="M0,56.5c0,0,298.666,0,399.333,0C448.336,56.5,513.994,46,597,46c77.327,0,135,10.5,200.999,10.5c95.996,0,402.001,0,402.001,0">
+                    </path>
+                  </svg>
+                </a>
+                <div class="dropdown-menu megamenu animate fade-down" role="menu">
+                  <div class="container">
+                    <div class="section-inner-expanded">
+                      <div class="row g-3">
+                        <div class="col-12 col-md-6">
+                          <div class="megamenu-item h-auto">
+                            <h6 class="title text-white">Organisers</h6>
+                          </div>
+                          <div class="row g-3">
+                            <div class="col-12 col-md-6">
+                              <div class="megamenu-item">
+                                <ul class="nav-list list-unstyled">
+                                  <li class="nav-item">
+                                    <a href="education.html" class="nav-link">
+                                      <span class="text">Education</span>
+                                    </a>
+                                  </li>
+                                  <li class="nav-item">
+                                    <a href="community-code-of-conducts.html" class="nav-link">
+                                      <span class="text">Community: Code of Conducts</span>
+                                    </a>
+                                  </li>
+                                  <li class="nav-item">
+                                    <a href="di-practices.html" class="nav-link">
+                                      <span class="text">D&I Practices</span>
+                                    </a>
+                                  </li>
+                                  <li class="nav-item">
+                                    <a href="event-organiser-material.html" class="nav-link">
+                                      <span class="text">Event Organiser Material</span>
+                                    </a>
+                                  </li>
+                                </ul>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="col-12 col-md-6 col-lg-3">
+                          <div class="megamenu-item">
+                            <a href="element-carousel.html" target="_blank" class="megamenu-image secondary">
+                              <img src="assets/images/gif/d&i.gif" alt="Image name" class="image">
+                              <span class="title"></span>
+                            </a>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </nav>
+  </header>
+
+  <!-- Main -->
+  <main id="main" class="shock-main bg-color black">
+
+    <!-- Banner -->
+    <section class="shock-section bg-image bg-fixed position-x-left" data-bg-image="assets/images/jpg/bg3.jpg">
+      <div class="container">
+        <div class="holder vh-100 align-h-right align-v-center">
+          <!-- Intro -->
+          <div class="side-intro max-w-50">
+            <h2 class="title">
+              <span class="text-1 text-style-1 text-outline text-gradient scheme-2"
+                data-text-color="#101e20">Education</span>
+              <span class="text-2 text-style-2 text-italic text-gradient scheme-2">Resources and Initiatives</span>
+            </h2>
+            <div class="description text-style-12 gray">
+              <p>Explore our educational resources and initiatives to promote diversity and inclusion in the Python community.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Education Content -->
+    <section class="shock-section pt-5 pb-3">
+      <div class="container">
+        <!-- Intro -->
+        <div class="extended-intro max-w-85">
+          <div class="wrapper">
+            <div class="left-column">
+              <h2 class="title">
+                <span class="text-1 text-style-2 text-outline text-gradient scheme-2" data-text-color="#1e1e24">Educational Resources</span>
+                <span class="text-2 text-style-3 text-italic text-gradient scheme-2">Learn and Grow</span>
+              </h2>
+              <div class="description text-style-12 gray">
+                <p>We provide a variety of educational resources to help you learn and grow in the Python community.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <!-- Resources -->
+        <div class="gallery stretched has-gap scrolling-grid">
+          <div class="bricklayer" data-columns="4">
+            <a href="assets/images/jpg/resources/resource1.jpg" class="item lightbox-link">
+              <div class="image-wrapper small-shadow rounded hover-zoom-rotate">
+                <img src="assets/images/jpg/resources/resource1.jpg" class="image" alt="Resource 1" />
+                <h3 class="title m-0 text-style-11 text-white">Resource 1</h3>
+                <p class="text-white">Description of Resource 1</p>
+                <div class="overlay secondary-25 text-white"></div>
+              </div>
+            </a>
+            <a href="assets/images/jpg/resources/resource2.jpg" class="item lightbox-link">
+              <div class="image-wrapper small-shadow rounded hover-zoom-rotate">
+                <img src="assets/images/jpg/resources/resource2.jpg" class="image" alt="Resource 2" />
+                <h3 class="title m-0 text-style-11 text-white">Resource 2</h3>
+                <p class="text-white">Description of Resource 2</p>
+                <div class="overlay secondary-25"></div>
+              </div>
+            </a>
+            <a href="assets/images/jpg/resources/resource3.jpg" class="item lightbox-link">
+              <div class="image-wrapper small-shadow rounded hover-zoom-rotate">
+                <img src="assets/images/jpg/resources/resource3.jpg" class="image" alt="Resource 3" />
+                <h3 class="title m-0 text-style-11 text-white">Resource 3</h3>
+                <p class="text-white">Description of Resource 3</p>
+                <div class="overlay secondary-25"></div>
+              </div>
+            </a>
+            <a href="assets/images/jpg/resources/resource4.jpg" class="item lightbox-link">
+              <div class="image-wrapper small-shadow rounded hover-zoom-rotate">
+                <img src="assets/images/jpg/resources/resource4.jpg" class="image" alt="Resource 4" />
+                <h3 class="title m-0 text-style-11 text-white">Resource 4</h3>
+                <p class="text-white">Description of Resource 4</p>
+                <div class="overlay secondary-25"></div>
+              </div>
+            </a>
+          </div>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <!-- Footer -->
+  <footer id="footer" class="dni-footer scheme-1 tertiary">
+    <div class="footer-content focus-trigger">
+      <div class="container">
+        <div class="row g-3">
+          <div class="col-12 col-md-6 col-lg-3">
+            <div class="footer-item">
+              <!-- Brand -->
+              <a href="/" class="footer-brand">
+                <img src="assets/images/logo-dni.svg" alt="PSF Diversity & Inclusion Workgroup" class="logo" />
+                <span class="logo-after-text">D&I Workgroup</span>
+              </a>
+              <img src="assets/images/png/psf-logo-white.png" class="image" alt="New York Statue of Liberty" />
+              <!-- Text -->
+              <div class="footer-text">
+                <p>The Diversity and Inclusion Working Group is a volunteer workgroup of the Python Software Foundation.
+                </p>
+              </div>
+            </div>
+            <div class="footer-item">
+              <!-- Icon list -->
+              <div class="list-wrapper">
+                <ul class="icon-h-list">
+                  <li class="item">
+                    <a href="https://twitter.com/ThePSF" class="link gray tertiary-hover hover-rotate"><i
+                        class="icon fab fa-twitter"></i></a>
+                  </li>
+                  <li class="item">
+                    <a href="https://www.linkedin.com/company/thepsf/" class="link gray tertiary-hover hover-rotate"><i
+                        class="icon fab fa-linkedin-in"></i></a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+          <div class="col-12 col-md-6 col-lg-3">
+            <div class="footer-item">
+              <h6 class="title">Popular Searches</h6>
+              <!-- Tag Cloud -->
+              <div class="tag-cloud">
+                <a href="#your-link" class="link">
+                  <span class="badge outline gray-50 tertiary-hover">
+                    <span class="badge-text gray white-hover">Stories</span>
+                  </span>
+                </a>
+                <a href="#your-link" class="link">
+                  <span class="badge outline gray-50 tertiary-hover floating-item-smooth">
+                    <span class="badge-text gray white-hover">Events</span>
+                  </span>
+                </a>
+                <a href="#your-link" class="link">
+                  <span class="badge outline gray-50 tertiary-hover">
+                    <span class="badge-text gray white-hover">Technology</span>
+                  </span>
+                </a>
+                <a href="#your-link" class="link">
+                  <span class="badge outline gray-50 tertiary-hover">
+                    <span class="badge-text gray white-hover">Motivational</span>
+                  </span>
+                </a>
+                <a href="#your-link" class="link">
+                  <span class="badge outline gray-50 tertiary-hover">
+                    <span class="badge-text gray white-hover">Heroes</span>
+                  </span>
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="bottom-bar">
+      <div class="text">© 2022 - All rights reserved. This website is maintained by the <a
+          href="https://www.python.org/psf-landing/" class="link gray primary-hover"><u>PSF</u></a> <a
+          href="https://wiki.python.org/psf/DiversityandInclusionWG" class="link gray primary-hover"><u>Diversity and
+            Inclusion</u></a> Workgroup.</div>
+    </div>
+  </footer>
+
+  <!-- Vendor JavaScript -->
+  <script src="assets/js/vendor/jquery.min.js"></script>
+  <script src="assets/js/vendor/imagesloaded.pkgd.min.js"></script>
+  <script src="assets/js/vendor/inview.min.js"></script>
+  <script src="assets/js/vendor/menu-engine.min.js"></script>
+  <script src="assets/js/vendor/menu-grid.min.js"></script>
+  <script src="assets/js/vendor/bootstrap.min.js"></script>
+  <script src="assets/js/vendor/swiper.min.js"></script>
+  <script src="assets/js/vendor/anime.min.js"></script>
+  <script src="assets/js/vendor/dynamic-slider.min.js"></script>
+  <script src="assets/js/vendor/shuffle.min.js"></script>
+  <script src="assets/js/vendor/stickybits.min.js"></script>
+  <script src="assets/js/vendor/bricklayer.min.js"></script>
+  <script src="assets/js/vendor/lightbox.min.js"></script>
+  <script src="assets/js/vendor/typed.min.js"></script>
+  <script src="assets/js/vendor/progressbar.min.js"></script>
+  <script src="assets/js/vendor/map-styles.min.js"></script>
+  <script src="assets/js/vendor/magnetic-effect.min.js"></script>
+  <script src='assets/js/vendor/gsap.min.js'></script>
+  <script src="assets/js/vendor/aos.min.js"></script>
+  <script src="assets/js/vendor/lax.min.js"></script>
+  <script src="assets/js/vendor/cursor-effect.min.js"></script>
+
+  <!-- Main JavaScript -->
+  <script src="assets/js/main.js"></script>
+
+</body>
+
+</html>

--- a/event-organiser-material.html
+++ b/event-organiser-material.html
@@ -1,0 +1,498 @@
+<!DOCTYPE HTML>
+<html lang="en">
+
+<head>
+
+  <!-- Display -->
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+  <!-- Identity -->
+  <title>Event Organiser Material</title>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <meta property="og:title" content="Event Organiser Material" />
+  <meta property="og:type" content="website" />
+  <meta name="description" content="Resources and materials for event organisers.">
+  <meta property="og:url" content="https://url" />
+  <meta property="og:image" content="" />
+  <link rel="shortcut icon" href="assets/images/favicon.ico" type="image/x-icon" />
+
+  <!-- Vendor Style Sheet -->
+  <link rel="stylesheet" href="assets/css/vendor/font-family.min.css" />
+  <link rel="stylesheet" href="assets/css/vendor/font-awesome.min.css" />
+  <link rel="stylesheet" href="assets/css/vendor/menu-engine.min.css" />
+  <link rel="stylesheet" href="assets/css/vendor/menu-grid.min.css" />
+  <link rel="stylesheet" href="assets/css/vendor/bootstrap.min.css" />
+  <link rel="stylesheet" href="assets/css/vendor/swiper.min.css" />
+  <link rel="stylesheet" href="assets/css/vendor/dynamic-slider.min.css" />
+  <link rel="stylesheet" href="assets/css/vendor/bricklayer.min.css" />
+  <link rel="stylesheet" href="assets/css/vendor/lightbox.min.css" />
+  <link rel="stylesheet" href="assets/css/vendor/aos.min.css" />
+
+  <!-- Main Style Sheet -->
+  <link rel="stylesheet" href="assets/css/theme.css" />
+  <link rel="stylesheet" href="assets/css/core.css" />
+  <link rel="stylesheet" href="assets/css/main.css" />
+
+</head>
+
+<body class="shock-body">
+
+  <!-- Preloader -->
+  <div id="preloader" class="preloader black" data-bg-image="assets/images/logo-dni.svg"></div>
+
+  <!-- Header -->
+  <header id="header" class="shock-header">
+    <!-- Navbar -->
+    <nav id="navbar" class="navbar navbar-centered navbar-expand-lg auto-hide scheme-1 tertiary">
+      <div class="container">
+        <!-- Brand -->
+        <a class="navbar-brand" href="https://psf.github.io/diversity-and-inclusion-wg/" target="_blank">
+          <img src="assets/images/logo-dni.svg" data-logo-alt="assets/images/logo-dni.svg"
+            data-logo-mobile="assets/images/logo-dni.svg" alt="PSF Diversity and Inclusion WG" class="logo" />
+        </a>
+        <!-- Responsive menu toggle -->
+        <button class="navbar-toggler" data-bs-target="#navbar-items" data-bs-toggle="collapse" aria-expanded="false">
+          <span class="navbar-toggler-icon">
+            <span class="line"></span>
+            <span class="line"></span>
+            <span class="line"></span>
+          </span>
+        </button>
+        <div id="navbar-items" class="collapse navbar-collapse">
+          <div class="navbar-left">
+            <!-- Link -->
+            <ul class="navbar-nav">
+              <li class="nav-item">
+                <a href="#about" class="nav-link flutter-underline">
+                  <span class="text">Who are we</span>
+                  <svg class="flutter-underline-graphic" width="300%" height="100%" viewBox="0 0 1200 60"
+                    preserveAspectRatio="none">
+                    <path
+                      d="M0,56.5c0,0,298.666,0,399.333,0C448.336,56.5,513.994,46,597,46c77.327,0,135,10.5,200.999,10.5c95.996,0,402.001,0,402.001,0">
+                    </path>
+                  </svg>
+                </a>
+              </li>
+              <a href="#agenda" class="nav-link flutter-underline">
+                <span class="text">Agenda</span>
+                <svg class="flutter-underline-graphic" width="300%" height="100%" viewBox="0 0 1200 60"
+                  preserveAspectRatio="none">
+                  <path
+                    d="M0,56.5c0,0,298.666,0,399.333,0C448.336,56.5,513.994,46,597,46c77.327,0,135,10.5,200.999,10.5c95.996,0,402.001,0,402.001,0">
+                  </path>
+                </svg>
+              </a>
+              <li class="nav-item dropdown has-megamenu hover">
+                <a class="nav-link dropdown-toggle has-icon flutter-underline" href="#" data-bs-toggle="dropdown">
+                  <span class="text">Videos</span><img class="image-icon dropdown-icon"
+                    src="assets/svg/chevron-down-outline.svg" alt="Icon name" data-dni-icon="32" />
+                  <svg class="flutter-underline-graphic" width="300%" height="100%" viewBox="0 0 1200 60"
+                    preserveAspectRatio="none">
+                    <path
+                      d="M0,56.5c0,0,298.666,0,399.333,0C448.336,56.5,513.994,46,597,46c77.327,0,135,10.5,200.999,10.5c95.996,0,402.001,0,402.001,0">
+                    </path>
+                  </svg>
+                </a>
+                <div class="dropdown-menu megamenu animate fade-down" role="menu">
+                  <div class="container">
+                    <div class="section-inner-expanded">
+                      <div class="row g-3">
+                        <div class="col-12 col-md-6">
+                          <div class="megamenu-item h-auto">
+                            <h6 class="title text-white">Previous Meets</h6>
+                          </div>
+                          <div class="row g-3">
+                            <div class="col-12 col-md-6">
+                              <div class="megamenu-item">
+                                <ul class="nav-list list-unstyled">
+                                  <li class="nav-item">
+                                    <a href="-" class="nav-link">
+                                      <span class="text">January 31, 2023</span>
+                                      <span class="badge ms-05 primary-15 primary-15-hover">
+                                        <span class="badge-text primary primary-hover">Latest</span>
+                                      </span>
+                                    </a>
+                                  </li>
+                                </ul>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="col-12 col-md-6 col-lg-3">
+                          <div class="megamenu-item">
+                            <a href="element-carousel.html" target="_blank" class="megamenu-image secondary">
+                              <img src="assets/images/gif/d&i.gif" alt="Image name" class="image">
+                              <span class="title"></span>
+                            </a>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </li>
+            </ul>
+          </div>
+          <div class="navbar-right">
+            <!-- Link -->
+            <ul class="navbar-nav">
+              <li class="nav-item dropdown has-megamenu hover">
+                <a href="#faqs" class="nav-link flutter-underline">
+                  <span class="text">FAQ</span>
+                  <svg class="flutter-underline-graphic" width="300%" height="100%" viewBox="0 0 1200 60"
+                    preserveAspectRatio="none">
+                    <path
+                      d="M0,56.5c0,0,298.666,0,399.333,0C448.336,56.5,513.994,46,597,46c77.327,0,135,10.5,200.999,10.5c95.996,0,402.001,0,402.001,0">
+                    </path>
+                  </svg>
+                </a>
+                <div class="dropdown-menu megamenu animate fade-down" role="menu">
+                  <div class="container">
+                  </div>
+                </div>
+              </li>
+              <li class="nav-item dropdown has-megamenu hover">
+                <a class="nav-link dropdown-toggle has-icon flutter-underline" href="#" data-bs-toggle="dropdown">
+                  <span class="text">Community Spotlight</span><img class="image-icon dropdown-icon"
+                    src="assets/svg/chevron-down-outline.svg" alt="Icon name" data-dni-icon="32" />
+                  <svg class="flutter-underline-graphic" width="300%" height="100%" viewBox="0 0 1200 60"
+                    preserveAspectRatio="none">
+                    <path
+                      d="M0,56.5c0,0,298.666,0,399.333,0C448.336,56.5,513.994,46,597,46c77.327,0,135,10.5,200.999,10.5c95.996,0,402.001,0,402.001,0">
+                    </path>
+                  </svg>
+                </a>
+                <div class="dropdown-menu megamenu animate fade-down" role="menu">
+                  <div class="container">
+                    <div class="section-inner-expanded">
+                      <div class="row g-3">
+                        <div class="col-12 col-md-6">
+                          <div class="megamenu-item h-auto">
+                            <h6 class="title text-white">Most Recent Showcase</h6>
+                          </div>
+                          <div class="row g-3">
+                            <div class="col-12 col-md-6">
+                              <div class="megamenu-item">
+                                <ul class="nav-list list-unstyled">
+                                  <li class="nav-item">
+                                    <a href="https://observablehq.com/@terezaif/who-voted-in-the-psf-board-elections"
+                                      class="nav-link">
+                                      <span class="text">PSF ELection Voters</span>
+                                      <span class="badge ms-05 primary-15 primary-15-hover">
+                                        <span class="badge-text primary primary-hover">Latest</span>
+                                      </span>
+                                    </a>
+                                  </li>
+                                  <li class="nav-item">
+                                    <a href="post-2.html" class="nav-link parent">
+                                      <span class="text">Story 2</span>
+                                    </a>
+                                  </li>
+                                  <li class="nav-item">
+                                    <a href="post-3.html" class="nav-link">
+                                      <span class="text">Story 3</span>
+                                    </a>
+                                  </li>
+                                  <li class="nav-item">
+                                    <a href="post-4.html" class="nav-link parent">
+                                      <span class="text">Story 4</span>
+                                    </a>
+                                  </li>
+                                  <li class="nav-item">
+                                    <a href="post-5.html" class="nav-link">
+                                      <span class="text">Story 5</span>
+                                    </a>
+                                  </li>
+                                </ul>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="col-12 col-md-6 col-lg-3">
+                          <div class="megamenu-item">
+                            <h6 class="title text-white">Python Heroes</h6>
+                            <ul class="nav-list list-unstyled">
+                              <li class="nav-item">
+                                <a href="blog-post-1.html" class="nav-link">
+                                  <span class="text">Hero 1</span>
+                                </a>
+                              </li>
+                              <li class="nav-item">
+                                <a href="blog-post-2.html" class="nav-link">
+                                  <span class="text">Hero 2</span>
+                                </a>
+                              </li>
+                              <li class="nav-item">
+                                <a href="blog-post-3.html" class="nav-link">
+                                  <span class="text">Hero 3</span>
+                                </a>
+                              </li>
+                              <li class="nav-item">
+                                <a href="blog-post-4.html" class="nav-link">
+                                  <span class="text">Hero 4</span>
+                                </a>
+                              </li>
+                              <li class="nav-item">
+                                <a href="blog-post-5.html" class="nav-link">
+                                  <span class="text">Hero 5</span>
+                                </a>
+                              </li>
+                              <li class="nav-item">
+                                <a href="blog-post-6.html" class="nav-link">
+                                  <span class="text">Hero 6</span>
+                                </a>
+                              </li>
+                            </ul>
+                          </div>
+                        </div>
+                        <div class="col-12 col-md-6 col-lg-3">
+                          <div class="megamenu-item">
+                            <a href="element-carousel.html" target="_blank" class="megamenu-image secondary">
+                              <img src="assets/images/gif/spot.gif" alt="spotlight gif" class="image">
+                              <span class="title">Spotlight</span>
+                            </a>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </li>
+              <li class="nav-item dropdown has-megamenu hover">
+                <a class="nav-link dropdown-toggle has-icon flutter-underline" href="#" data-bs-toggle="dropdown">
+                  <span class="text">Organisers</span><img class="image-icon dropdown-icon"
+                    src="assets/svg/chevron-down-outline.svg" alt="Icon name" data-dni-icon="32" />
+                  <svg class="flutter-underline-graphic" width="300%" height="100%" viewBox="0 0 1200 60"
+                    preserveAspectRatio="none">
+                    <path
+                      d="M0,56.5c0,0,298.666,0,399.333,0C448.336,56.5,513.994,46,597,46c77.327,0,135,10.5,200.999,10.5c95.996,0,402.001,0,402.001,0">
+                    </path>
+                  </svg>
+                </a>
+                <div class="dropdown-menu megamenu animate fade-down" role="menu">
+                  <div class="container">
+                    <div class="section-inner-expanded">
+                      <div class="row g-3">
+                        <div class="col-12 col-md-6">
+                          <div class="megamenu-item h-auto">
+                            <h6 class="title text-white">Organisers</h6>
+                          </div>
+                          <div class="row g-3">
+                            <div class="col-12 col-md-6">
+                              <div class="megamenu-item">
+                                <ul class="nav-list list-unstyled">
+                                  <li class="nav-item">
+                                    <a href="education.html" class="nav-link">
+                                      <span class="text">Education</span>
+                                    </a>
+                                  </li>
+                                  <li class="nav-item">
+                                    <a href="community-code-of-conducts.html" class="nav-link">
+                                      <span class="text">Community: Code of Conducts</span>
+                                    </a>
+                                  </li>
+                                  <li class="nav-item">
+                                    <a href="di-practices.html" class="nav-link">
+                                      <span class="text">D&I Practices</span>
+                                    </a>
+                                  </li>
+                                  <li class="nav-item">
+                                    <a href="event-organiser-material.html" class="nav-link">
+                                      <span class="text">Event Organiser Material</span>
+                                    </a>
+                                  </li>
+                                </ul>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="col-12 col-md-6 col-lg-3">
+                          <div class="megamenu-item">
+                            <a href="element-carousel.html" target="_blank" class="megamenu-image secondary">
+                              <img src="assets/images/gif/d&i.gif" alt="Image name" class="image">
+                              <span class="title"></span>
+                            </a>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </nav>
+  </header>
+
+  <!-- Main -->
+  <main id="main" class="shock-main bg-color black">
+
+    <!-- Banner -->
+    <section class="shock-section bg-image bg-fixed position-x-left" data-bg-image="assets/images/jpg/bg3.jpg">
+      <div class="container">
+        <div class="holder vh-100 align-h-right align-v-center">
+          <!-- Intro -->
+          <div class="side-intro max-w-50">
+            <h2 class="title">
+              <span class="text-1 text-style-1 text-outline text-gradient scheme-2"
+                data-text-color="#101e20">Event</span>
+              <span class="text-2 text-style-2 text-italic text-gradient scheme-2">Organiser Material</span>
+            </h2>
+            <div class="description text-style-12 gray">
+              <p>Resources and materials for event organisers.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Event Organiser Material Contents -->
+    <section class="shock-section pt-5 pb-3">
+      <div class="container">
+        <!-- Intro -->
+        <div class="extended-intro max-w-85">
+          <div class="wrapper">
+            <div class="left-column">
+              <h2 class="title">
+                <span class="text-1 text-style-2 text-outline text-gradient scheme-2" data-text-color="#1e1e24">Resources for Event Organisers</span>
+                <span class="text-2 text-style-3 text-italic text-gradient scheme-2">Get the materials you need.</span>
+              </h2>
+              <div class="description text-style-12 gray">
+                <p>Find all the resources and materials you need to organise successful events.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <!-- Resources -->
+        <div class="gallery stretched has-gap scrolling-grid">
+          <div class="bricklayer" data-columns="4">
+            <a href="assets/images/jpg/resources/resource1.jpg" class="item lightbox-link">
+              <div class="image-wrapper small-shadow rounded hover-zoom-rotate">
+                <img src="assets/images/jpg/resources/resource1.jpg" class="image" alt="Resource 1" />
+                <h3 class="title m-0 text-style-11 text-white">Resource 1</h3>
+                <p class="text-white">Description of Resource 1</p>
+                <div class="overlay secondary-25 text-white"></div>
+              </div>
+            </a>
+            <a href="assets/images/jpg/resources/resource2.jpg" class="item lightbox-link">
+              <div class="image-wrapper small-shadow rounded hover-zoom-rotate">
+                <img src="assets/images/jpg/resources/resource2.jpg" class="image" alt="Resource 2" />
+                <h3 class="title m-0 text-style-11 text-white">Resource 2</h3>
+                <p class="text-white">Description of Resource 2</p>
+                <div class="overlay secondary-25"></div>
+              </div>
+            </a>
+            <a href="assets/images/jpg/resources/resource3.jpg" class="item lightbox-link">
+              <div class="image-wrapper small-shadow rounded hover-zoom-rotate">
+                <img src="assets/images/jpg/resources/resource3.jpg" class="image" alt="Resource 3" />
+                <h3 class="title m-0 text-style-11 text-white">Resource 3</h3>
+                <p class="text-white">Description of Resource 3</p>
+                <div class="overlay secondary-25"></div>
+              </div>
+            </a>
+            <a href="assets/images/jpg/resources/resource4.jpg" class="item lightbox-link">
+              <div class="image-wrapper small-shadow rounded hover-zoom-rotate">
+                <img src="assets/images/jpg/resources/resource4.jpg" class="image" alt="Resource 4" />
+                <h3 class="title m-0 text-style-11 text-white">Resource 4</h3>
+                <p class="text-white">Description of Resource 4</p>
+                <div class="overlay secondary-25"></div>
+              </div>
+            </a>
+          </div>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <!-- Footer -->
+  <footer id="footer" class="dni-footer scheme-1 tertiary">
+    <div class="footer-content focus-trigger">
+      <div class="container">
+        <div class="row g-3">
+          <div class="col-12 col-md-6 col-lg-3">
+            <div class="footer-item">
+              <!-- Brand -->
+              <a href="/" class="footer-brand">
+                <img src="assets/images/logo-dni.svg" alt="PSF Diversity & Inclusion Workgroup" class="logo" />
+                <span class="logo-after-text">D&I Workgroup</span>
+              </a>
+              <img src="assets/images/png/psf-logo-white.png" class="image" alt="New York Statue of Liberty" />
+              <!-- Text -->
+              <div class="footer-text">
+                <p>The Diversity and Inclusion Working Group is a volunteer workgroup of the Python Software Foundation.
+                </p>
+              </div>
+            </div>
+            <div class="footer-item">
+              <!-- Icon list -->
+              <div class="list-wrapper">
+                <ul class="icon-h-list">
+                  <li class="item">
+                    <a href="https://twitter.com/ThePSF" class="link gray tertiary-hover hover-rotate"><i
+                        class="icon fab fa-twitter"></i></a>
+                  </li>
+                  <li class="item">
+                    <a href="https://www.linkedin.com/company/thepsf/" class="link gray tertiary-hover hover-rotate"><i
+                        class="icon fab fa-linkedin-in"></i></a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="bottom-bar">
+      <div class="text">© 2022 - All rights reserved. This website is maintained by the <a
+          href="https://www.python.org/psf-landing/" class="link gray primary-hover"><u>PSF</u></a> <a
+          href="https://wiki.python.org/psf/DiversityandInclusionWG" class="link gray primary-hover"><u>Diversity and
+            Inclusion</u></a> Workgroup.</div>
+    </div>
+  </footer>
+
+  <!-- Cursor -->
+  <svg class="cursor-effect tertiary" width="220" height="220" viewBox="0 0 220 220">
+    <defs>
+      <filter id="cursor-effect-filter" x="-50%" y="-50%" width="200%" height="200%" filterUnits="objectBoundingBox">
+        <feTurbulence type="fractalNoise" baseFrequency="0" numOctaves="1" result="warp"></feTurbulence>
+        <feOffset dx="-30" result="warpOffset"></feOffset>
+        <feDisplacementMap xChannelSelector="R" yChannelSelector="G" scale="20" in="SourceGraphic" in2="warpOffset">
+        </feDisplacementMap>
+      </filter>
+    </defs>
+    <circle class="cursor-effect-inner" cx="110" cy="110" r="20"></circle>
+  </svg>
+
+  <!-- Vendor JavaScript -->
+  <script src="assets/js/vendor/jquery.min.js"></script>
+  <script src="assets/js/vendor/imagesloaded.pkgd.min.js"></script>
+  <script src="assets/js/vendor/inview.min.js"></script>
+  <script src="assets/js/vendor/menu-engine.min.js"></script>
+  <script src="assets/js/vendor/menu-grid.min.js"></script>
+  <script src="assets/js/vendor/bootstrap.min.js"></script>
+  <script src="assets/js/vendor/swiper.min.js"></script>
+  <script src="assets/js/vendor/anime.min.js"></script>
+  <script src="assets/js/vendor/dynamic-slider.min.js"></script>
+  <script src="assets/js/vendor/shuffle.min.js"></script>
+  <script src="assets/js/vendor/stickybits.min.js"></script>
+  <script src="assets/js/vendor/bricklayer.min.js"></script>
+  <script src="assets/js/vendor/lightbox.min.js"></script>
+  <script src="assets/js/vendor/typed.min.js"></script>
+  <script src="assets/js/vendor/progressbar.min.js"></script>
+  <script src="assets/js/vendor/map-styles.min.js"></script>
+  <script src="assets/js/vendor/magnetic-effect.min.js"></script>
+  <script src='assets/js/vendor/gsap.min.js'></script>
+  <script src="assets/js/vendor/aos.min.js"></script>
+  <script src="assets/js/vendor/lax.min.js"></script>
+  <script src="assets/js/vendor/cursor-effect.min.js"></script>
+
+  <!-- Main JavaScript -->
+  <script src="assets/js/main.js"></script>
+
+</body>
+
+</html>

--- a/index.html
+++ b/index.html
@@ -420,9 +420,10 @@
                   </div>
                 </div>
               </li>
-              <li class="nav-item">
-                <a href="https://events.hubilo.com/dni-friendly-chat/register" target="_blank" class="nav-link flutter-underline">
-                  <span class="text">Meet us!</span>
+              <li class="nav-item dropdown has-megamenu hover">
+                <a class="nav-link dropdown-toggle has-icon flutter-underline" href="#" data-bs-toggle="dropdown">
+                  <span class="text">Organisers</span><img class="image-icon dropdown-icon"
+                    src="assets/svg/chevron-down-outline.svg" alt="Icon name" data-dni-icon="32" />
                   <svg class="flutter-underline-graphic" width="300%" height="100%" viewBox="0 0 1200 60"
                     preserveAspectRatio="none">
                     <path
@@ -430,6 +431,55 @@
                     </path>
                   </svg>
                 </a>
+                <div class="dropdown-menu megamenu animate fade-down" role="menu">
+                  <div class="container">
+                    <div class="section-inner-expanded">
+                      <div class="row g-3">
+                        <div class="col-12 col-md-6">
+                          <div class="megamenu-item h-auto">
+                            <h6 class="title text-white">Organisers</h6>
+                          </div>
+                          <div class="row g-3">
+                            <div class="col-12 col-md-6">
+                              <div class="megamenu-item">
+                                <ul class="nav-list list-unstyled">
+                                  <li class="nav-item">
+                                    <a href="education.html" class="nav-link">
+                                      <span class="text">Education</span>
+                                    </a>
+                                  </li>
+                                  <li class="nav-item">
+                                    <a href="community-code-of-conducts.html" class="nav-link">
+                                      <span class="text">Community: Code of Conducts</span>
+                                    </a>
+                                  </li>
+                                  <li class="nav-item">
+                                    <a href="di-practices.html" class="nav-link">
+                                      <span class="text">D&I Practices</span>
+                                    </a>
+                                  </li>
+                                  <li class="nav-item">
+                                    <a href="event-organiser-material.html" class="nav-link">
+                                      <span class="text">Event Organiser Material</span>
+                                    </a>
+                                  </li>
+                                </ul>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="col-12 col-md-6 col-lg-3">
+                          <div class="megamenu-item">
+                            <a href="element-carousel.html" target="_blank" class="megamenu-image secondary">
+                              <img src="assets/images/gif/d&i.gif" alt="Image name" class="image">
+                              <span class="title"></span>
+                            </a>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
               </li>
             </ul>
             <!-- Icon -->


### PR DESCRIPTION
Create Community Organiser pages.

* Modify the "Meet Us!" menu option to be a dropdown menu labelled "Organisers".
* Add menu items "Education", "Community: Code of Conduct", "D&I Practices", and "Event Organiser Material" to the dropdown menu.
* Ensure each menu item navigates to the respective pages.
* Follow the current style and W3C standards with accessibility.

